### PR TITLE
Fix for crash on connection error

### DIFF
--- a/rhea/rhea.js
+++ b/rhea/rhea.js
@@ -60,6 +60,15 @@ module.exports = function(RED) {
 
                 node.connection = container.connect(options);
 
+                node.connection.on('connection_error', function(context) {
+
+                    node.connecting = false;
+                    node.connected = false;
+                    var error = context.connection.get_error();
+                    node.error(error);
+                    
+                });
+
                 node.connection.on('connection_open', function(context) {
 
                     node.connecting = false;


### PR DESCRIPTION
Fix for issue #12 

Fixes an issue where node-red would crash on rhea connection errors.
Introduces a new connection_error handler. Once a connection occurs, this handler uses node.error to
notify the user of the error.